### PR TITLE
Removed payout function

### DIFF
--- a/reaskapi/deepcyc.py
+++ b/reaskapi/deepcyc.py
@@ -45,15 +45,6 @@ class DeepCyc(ApiClient):
 
         return self._call_api(params, 'deepcyc/tcwind/returnvalues')
 
-    def tcwind_payout(self, portfolio, curve, **kwargs):
-
-        params = kwargs.copy()
-
-        post_data = { 'portfolio': portfolio, 'curve': curve }
-        self.logger.debug(f'Parameters: {params}')
-
-        return self._call_api(params, 'deepcyc/tcwind/payout', 'POST', post_data)
-
 
     def tcwind_eventstats(self, lat, lon, geometry, **kwargs):
 


### PR DESCRIPTION
Removed `tcwind_payout` function from `DeepCyc` class because this endpoint is deprecated and will be removed from the api.

(Edit) Found unit-tests failed because the api now checks wind_speed_averaging_period and terrain_correction combination appropriately. Need to update test code in failing.